### PR TITLE
add package.json to deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ jobs:
           paths:
             - .git
             - build
+            - package.json
+            - package-lock.json
 
   deploy:
     docker:


### PR DESCRIPTION
Apparently you [can't persist the whole root workspace](https://circleci.com/docs/2.0/configuration-reference/#persist_to_workspace), so I'm just going to copy over the `package.json` and `package-lock.json` and along with `./build` and hope that that is enough to make it a valid npm package.