### PR TITLE
add keyboard click to table checkbox

### DIFF
--- a/src/components/buttons.js
+++ b/src/components/buttons.js
@@ -56,6 +56,7 @@ export class Button extends Component {
     this.onMouseDown = this.onMouseDown.bind(this);
     this.onMouseMove = this.onMouseMove.bind(this);
     this.onMouseUp = this.onMouseUp.bind(this);
+    this.onKeyDown = this.onKeyDown.bind(this);
   }
 
   // when user clicks button
@@ -88,6 +89,12 @@ export class Button extends Component {
       this.props.onMouseUp(event);
   }
 
+  // when user presses key with button focused
+  onKeyDown(event) {
+    if (this.props.onKeyDown)
+      this.props.onKeyDown(event);
+  }
+
   // display component
   render() {
     const Button = this.props.href ? 'a' : 'button';
@@ -100,6 +107,7 @@ export class Button extends Component {
           onMouseDown={this.onMouseDown}
           onMouseMove={this.onMouseMove}
           onMouseUp={this.onMouseUp}
+          onKeyDown={this.onKeyDown}
           data-disabled={this.props.disabled}
         >
           {this.props.children}

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -941,7 +941,7 @@ class BodyCheckboxCell extends Component {
     window.removeEventListener('mouseup', this.onMouseUp);
   }
 
-  // on click
+  // on key down
   onKeyDown() {
     this.context.toggleChecked(this.props.datum[rowIndexKey], this.props.field);
   }

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -421,9 +421,9 @@ export class Table extends Component {
       return data;
 
     return data.filter((datum) => {
-      const searchFields = this.props.searchAllFields
-        ? this.props.fields.concat(Object.keys(datum))
-        : this.props.fields;
+      const searchFields = this.props.searchAllFields ?
+        this.props.fields.concat(Object.keys(datum)) :
+        this.props.fields;
       for (const field of searchFields) {
         if (
           String(JSON.stringify(datum[field]))
@@ -921,6 +921,7 @@ class BodyCheckboxCell extends Component {
     // temporary checked state for dragging
     this.state.tempChecked = null;
 
+    this.onKeyDown = this.onKeyDown.bind(this);
     this.onCtrlClick = this.onCtrlClick.bind(this);
     this.onMouseDown = this.onMouseDown.bind(this);
     this.onMouseMove = this.onMouseMove.bind(this);
@@ -938,6 +939,11 @@ class BodyCheckboxCell extends Component {
   // when component unmounts
   componentWillUnmount() {
     window.removeEventListener('mouseup', this.onMouseUp);
+  }
+
+  // on click
+  onKeyDown() {
+    this.context.toggleChecked(this.props.datum[rowIndexKey], this.props.field);
   }
 
   // on ctrl+click
@@ -988,6 +994,7 @@ class BodyCheckboxCell extends Component {
         >
           <Button
             className={'table_button'}
+            onKeyDown={this.onKeyDown}
             onCtrlClick={this.onCtrlClick}
             onMouseDown={this.onMouseDown}
             onMouseMove={this.onMouseMove}
@@ -1014,9 +1021,9 @@ class BodyCell extends Component {
           style={this.props.style || {}}
           className={this.props.className || ''}
           data-highlighted={
-            this.props.datum[cellHighlightKey] === this.props.field
-              ? true
-              : false
+            this.props.datum[cellHighlightKey] === this.props.field ?
+              true :
+              false
           }
         >
           {this.props.content || ''}


### PR DESCRIPTION
To implement the drag-to-select function, I had to not capture a typical `onClick` event (which also handles pressing enter/space on a button/link). This manually implements a keypress click.